### PR TITLE
Define <symbol> in the component file.

### DIFF
--- a/src/hangul.xml.in.in
+++ b/src/hangul.xml.in.in
@@ -21,6 +21,7 @@
 			<longname>Korean</longname>
 			<description>Korean Input Method</description>
 			<rank>99</rank>
+			<symbol>&#xD55C;</symbol>
 		</engine>
 	</engines>
 


### PR DESCRIPTION
Hi,

ibus-1.4 added a few elements that can be defined in /usr/share/ibus/component/*.xml:
https://github.com/ibus/ibus/blob/master/src/ibusenginedesc.c#L566
Among them, I think "symbol" is generally useful.

Could you please consider defining it by default?  Actually I have added this patch in the Fedora package for a while and seen no problem.
