### PR TITLE
Make applying the “Automatic reordering” setup option work

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -127,6 +127,9 @@ class Setup ():
         word_commit = self.__word_commit.get_active()
         self.__write("WordCommit", word_commit)
 
+        auto_reorder = self.__auto_reorder.get_active()
+        self.__write("AutoReorder", auto_reorder)
+
         model = self.__hanja_key_list.get_model()
         str = ""
         iter = model.get_iter_first()


### PR DESCRIPTION
When opening the ibus-hangul setup, there is an option

```
[✓] Automatic reordering
```

Changing the status of this option and applying it does not work,
the option always reverts to the default.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=870318 

This change fixes this.
