### PR TITLE
build: use gnome-common to bootstrap

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,24 @@
 #!/bin/sh
-set -e
-set -x
+# Run this to generate all the initial makefiles, etc.
 
-touch ChangeLog
-autopoint --force
-libtoolize --automake --copy
-intltoolize --copy --force
-aclocal -I m4
-autoheader
-automake --add-missing --copy
-autoconf
-export CFLAGS="-Wall -g -O0 -Wl,--no-undefined"
-export CXXFLAGS="$CFLAGS"
-./configure --enable-maintainer-mode $*
+srcdir=`dirname $0`
+test -z "$srcdir" && srcdir=.
+
+PKG_NAME="ibus-hangul"
+
+(test -f $srcdir/configure.ac \
+  && test -f $srcdir/README ) || {
+    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
+    echo " top-level $PKG_NAME directory"
+    exit 1
+}
+
+which gnome-autogen.sh || {
+    echo "You need to install gnome-common from the GNOME CVS"
+    exit 1
+}
+
+ACLOCAL_FLAGS="$ACLOCAL_FLAGS -I m4"
+REQUIRED_AUTOMAKE_VERSION=1.8
+
+. gnome-autogen.sh


### PR DESCRIPTION
Some engines and IBus itself migrated to use gnome-common a while ago.  This would help packagers to regenerate configure scripts without running configure (NOCONFIGURE=1 ./autogen.sh).
