### PR TITLE
Use kr104 keyboard.

### DIFF
--- a/src/hangul.xml.in.in
+++ b/src/hangul.xml.in.in
@@ -17,7 +17,8 @@
 			<license>GPL</license>
 			<author>Peng Huang &lt;shawn.p.huang@gmail.com&gt;</author>
 			<icon>ibus-hangul</icon>
-			<layout>us</layout>
+			<layout>kr</layout>
+			<layout_variant>kr104</layout_variant>
 			<longname>Hangul</longname>
 			<description>Korean Input Method</description>
 			<rank>99</rank>


### PR DESCRIPTION
us keyboard layout doesn't have hangul key and therefore it's impossible to use hangul key at switch language.
I also set kr104 as variant for laptop users, but it will also makes right alt as hangul key in 106 keyboard mostly used in desktop.
