### PR TITLE
Don't use both AM_GNU_GETTEXT and IT_PROG_INTLTOOL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,9 +80,6 @@ GETTEXT_PACKAGE=ibus-hangul
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Define to the read-only architecture-independent data directory.])
 
-AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.17])
-
 
 # OUTPUT files
 AC_CONFIG_FILES([ po/Makefile.in


### PR DESCRIPTION
When using IT_PROG_INTLTOOL using the gettect automake macros isn't
necessary. To make matters worse, when mixing the marcos both try to
generate po/Makefile.in.in. Recent versions of intltool detect when
gettext won and bails when building.

See e.g. similar bug in gdm: https://bugzilla.gnome.org/show_bug.cgi?id=711818