### PR TITLE
Setup ui cleanup

### DIFF
--- a/setup/setup.ui
+++ b/setup/setup.ui
@@ -157,7 +157,7 @@
                             <property name="can_focus">False</property>
                             <child>
                               <object class="GtkCheckButton" id="StartInHangulMode">
-                                <property name="label" translatable="yes">Start in _hangul mode</property>
+                                <property name="label" translatable="yes">Start in _Hangul mode</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -261,7 +261,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Hangul toggle key&lt;/b&gt;</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Hangul Toggle Key&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
                       <packing>
@@ -399,7 +399,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="label" translatable="yes">&lt;b&gt;Hanja key&lt;/b&gt;</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Hanja Key&lt;/b&gt;</property>
                             <property name="use_markup">True</property>
                             <property name="wrap_mode">word-char</property>
                           </object>

--- a/setup/setup.ui
+++ b/setup/setup.ui
@@ -25,7 +25,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="border_width">6</property>
+                <property name="border_width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">18</property>
                 <child>


### PR DESCRIPTION
GNOME HIG에 따라 수정합니다

* 테두리-컨트롤 사이의 간격을 12픽셀로
* 헤더의 단어에 대문자를 사용합니다
