### PR TITLE
Use bind_textdomain_codeset() from gettext.

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -294,7 +294,7 @@ class Setup ():
 
 if __name__ == "__main__":
     locale.bindtextdomain(config.gettext_package, config.localedir)
-    locale.bind_textdomain_codeset(config.gettext_package, "UTF-8")
+    gettext.bind_textdomain_codeset(config.gettext_package, "UTF-8")
 
     bus = IBus.Bus()
     if bus.is_connected():


### PR DESCRIPTION
bind_textdomain_codeset() is part of the locale module on linux, but not
on openbsd.  It is always included in the gettext module though, which
is in fact the correct module to use.
From https://docs.python.org/2/library/locale.html:

The locale module exposes the C library’s gettext interface on systems
that provide this interface. It consists of the functions gettext(),
dgettext(), dcgettext(), textdomain(), bindtextdomain(), and
bind_textdomain_codeset(). These are similar to the same functions in
the gettext module, but use the C library’s binary format for message
catalogs, and the C library’s search algorithms for locating message
catalogs.