### PR TITLE
setup: Set GLib app name explicitly

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -295,6 +295,8 @@ class Setup ():
 if __name__ == "__main__":
     locale.bindtextdomain(config.gettext_package, config.localedir)
     locale.bind_textdomain_codeset(config.gettext_package, "UTF-8")
+    GLib.set_prgname("ibus-setup-hangul")
+    GLib.set_application_name(_("IBusHangul Setup"))
 
     bus = IBus.Bus()
     if bus.is_connected():


### PR DESCRIPTION
데비안 패키지 중 만든 수정 사항입니다. ibus-setup-hangul이 창 목록에서 Main.py로 보이는 현상을 수정합니다.

