### PR TITLE
setup: Fix PyGI warnings

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -20,8 +20,11 @@
 
 import sys
 import os
+import gi
 from gi.repository import GLib
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
+gi.require_version('IBus', '1.0')
 from gi.repository import IBus
 import locale
 import gettext


### PR DESCRIPTION
아래 PyGI warning 수정입니다.

```
main.py:24: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
main.py:25: PyGIWarning: IBus was imported without specifying a version first. Use gi.require_version('IBus', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import IBus

```