### PR TITLE
libhangul 0.2.0 자동 순서 교정

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,15 @@ PKG_CHECK_MODULES(GTK, [
     gtk+-3.0 >= 3.0.0
 ])
 
+# check hangul_ic_set_option() in libhangul newer version
+LIBS_BACKUP=$LIBS
+LIBS=$HANGUL_LIBS
+AC_CHECK_LIB(hangul, [hangul_ic_set_option],
+    [AC_DEFINE([LIBHANGUL_HAVE_HANGUL_IC_SET_OPTION], [1], [hangul_ic_set_option()])],
+    []
+)
+LIBS=$LIBS_BACKUP
+
 # check env
 AC_PATH_PROG(ENV_PROG, env)
 AC_SUBST(ENV_PROG)


### PR DESCRIPTION
https://github.com/libhangul/ibus-hangul/issues/49

0.2.0 릴리스됐으니 바꿀 때가 됐습니다.

-----

* Detect if hangul_ic_set_option() is available in libhangul, and use it to toggle option HANGUL_IC_OPTION_AUTO_REORDER.

* https://github.com/libhangul/ibus-hangul/issues/49