### PR TITLE
한/영 상태 표시를 더 명확하게 변경

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -1844,9 +1844,9 @@ ibus_hangul_engine_get_input_mode_symbol (IBusHangulEngine *hangul,
     IBusText **symbols = hangul->input_mode_symbols;
 
     if (symbols[0] == NULL) {
-        symbols[INPUT_MODE_HANGUL] = ibus_text_new_from_string ("한");
+        symbols[INPUT_MODE_HANGUL] = ibus_text_new_from_string ("한글");
         g_object_ref_sink(symbols[INPUT_MODE_HANGUL]);
-        symbols[INPUT_MODE_LATIN] = ibus_text_new_from_string ("EN");
+        symbols[INPUT_MODE_LATIN] = ibus_text_new_from_string ("영문");
         g_object_ref_sink(symbols[INPUT_MODE_LATIN]);
     }
 

--- a/src/hangul.xml.in.in
+++ b/src/hangul.xml.in.in
@@ -22,7 +22,7 @@
 			<longname>Hangul</longname>
 			<description>Korean Input Method</description>
 			<rank>99</rank>
-			<symbol>&#xD55C;</symbol>
+			<symbol>&#xD55C;&#xAE00;</symbol>
 			<setup>${libexecdir}/ibus-setup-hangul</setup>
 		</engine>
 	</engines>


### PR DESCRIPTION
* The Latin state was displayed as "EN" in gnome-shell, but the English XKB input source also shows as "en", causing confusion.

* Changed to "한글"/"영문".

https://github.com/libhangul/ibus-hangul/issues/127