### PR TITLE
Use full path on running .../libexec/ibus-setup-hangul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ po/stamp-it
 # files for setup
 setup/config.py
 setup/ibus-setup-hangul
+setup/ibus-setup-hangul.desktop
+setup/ibus-setup-hangul.desktop.in
 
 # files for engine
 src/test.sh

--- a/ibus-hangul.spec.in
+++ b/ibus-hangul.spec.in
@@ -45,7 +45,6 @@ rm -rf $RPM_BUILD_ROOT
 %files -f %{name}.lang
 %defattr(-,root,root,-)
 %doc AUTHORS COPYING README
-%{_bindir}/ibus-setup-hangul
 %{_libexecdir}/ibus-engine-hangul
 %{_libexecdir}/ibus-setup-hangul
 %{_datadir}/applications

--- a/setup/Makefile.am
+++ b/setup/Makefile.am
@@ -30,10 +30,18 @@ setup_hanguldir = $(pkgdatadir)/setup
 
 libexec_SCRIPTS = ibus-setup-hangul
 
-desktop_in_files = ibus-setup-hangul.desktop.in
+desktop_in_in_files = ibus-setup-hangul.desktop.in.in
+desktop_in_files = $(desktop_in_in_files:.desktop.in.in=.desktop.in)
 desktop_files = $(desktop_in_files:.desktop.in=.desktop)
 desktop_DATA = $(desktop_files)
 desktopdir = $(datadir)/applications
+
+# replace libexecdir
+$(desktop_in_files): %.desktop.in: %.desktop.in.in Makefile
+	$(AM_V_GEN) sed \
+	        -e "s|\@libexecdir\@|$(libexecdir)|" \
+	        -e "s|\@pkgdatadir\@|$(pkgdatadir)|" \
+	        $< > $@.tmp && mv $@.tmp $@
 
 $(desktop_files): $(desktop_in_files) Makefile
 	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@

--- a/setup/ibus-setup-hangul.desktop.in.in
+++ b/setup/ibus-setup-hangul.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=IBus Hangul Preferences
 Comment=Set IBus Hangul Preferences
-Exec=ibus-setup-hangul
+Exec=@libexecdir@/ibus-setup-hangul
 Icon=ibus-setup-hangul
 NoDisplay=true
 Terminal=false

--- a/src/engine.c
+++ b/src/engine.c
@@ -1786,7 +1786,7 @@ ibus_hangul_engine_property_activate (IBusEngine    *engine,
         GError *error = NULL;
         gchar *argv[2] = { NULL, };
 
-        argv[0] = "ibus-setup-hangul";
+        argv[0] = LIBEXECDIR "/ibus-setup-hangul";
         argv[1] = NULL;
         g_spawn_async (NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &error);
     } else if (strcmp(prop_name, "InputMode") == 0) {


### PR DESCRIPTION
ibus-setup-hangul is supposed to be launched by other programs.

* Remove ${bindir}/ibus-setup-hangul symlink installation.

* Specify the full ${libexecdir} path:
  - In ibus-setup-hangul.desktop, used when running gnome-setup-hangul in gnome-control-center.
  - On "setup" property activation, used when running gnome-setup-hangul in gnome-shell.

https://github.com/libhangul/ibus-hangul/issues/91